### PR TITLE
kovri-docs: move submodule to root dir, update symlinks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kovri.i2p/kovri-docs"]
-	path = kovri.i2p/kovri-docs
+	path = deps/kovri-docs
 	url = https://github.com/monero-project/kovri-docs.git

--- a/kovri.i2p/_i18n/en
+++ b/kovri.i2p/_i18n/en
@@ -1,1 +1,1 @@
-../kovri-docs/i18n/en/
+../../deps/kovri-docs/i18n/en/

--- a/kovri.i2p/_i18n/es
+++ b/kovri.i2p/_i18n/es
@@ -1,1 +1,1 @@
-../kovri-docs/i18n/es
+../../deps/kovri-docs/i18n/es/

--- a/kovri.i2p/_i18n/fr
+++ b/kovri.i2p/_i18n/fr
@@ -1,1 +1,1 @@
-../kovri-docs/i18n/fr
+../../deps/kovri-docs/i18n/fr/

--- a/kovri.i2p/_i18n/it
+++ b/kovri.i2p/_i18n/it
@@ -1,1 +1,1 @@
-../kovri-docs/i18n/it
+../../deps/kovri-docs/i18n/it/

--- a/kovri.i2p/_i18n/ru
+++ b/kovri.i2p/_i18n/ru
@@ -1,1 +1,1 @@
-../kovri-docs/i18n/ru
+../../deps/kovri-docs/i18n/ru/


### PR DESCRIPTION
Resolves Jekyll "directory is already being watched!" errors

Fixes #27.