### PR TITLE
Add noreferrer + noopener attributes to blank targets

### DIFF
--- a/kovri.i2p/_includes/footer.html
+++ b/kovri.i2p/_includes/footer.html
@@ -11,14 +11,14 @@
 </div> 
         <div class="row center-xs">
             <p>
-                <a class="white" href="https://github.com/monero-project/kovri-site" target="_blank">Source code</a> |
-                <a class="white" href="https://github.com/monero-project/kovri-site/blob/master/kovri.i2p/legal/terms.md" target="_blank">Terms of use</a> |
-                <a class="white" href="https://github.com/monero-project/kovri-site/blob/master/kovri.i2p/legal/privacy.md" target="_blank">Privacy policy</a> |
-                <a href="acknowledgements.html" class="white" target="_blank">Acknowledgements</a>
+                <a class="white" href="https://github.com/monero-project/kovri-site" target="_blank" rel="noreferrer, noopener">Source code</a> |
+                <a class="white" href="https://github.com/monero-project/kovri-site/blob/master/kovri.i2p/legal/terms.md" target="_blank" rel="noreferrer, noopener">Terms of use</a> |
+                <a class="white" href="https://github.com/monero-project/kovri-site/blob/master/kovri.i2p/legal/privacy.md" target="_blank" rel="noreferrer, noopener">Privacy policy</a> |
+                <a href="acknowledgements.html" class="white" target="_blank" rel="noreferrer, noopener">Acknowledgements</a>
             </p>
         </div> 
          <div class="row center-xs">
-               <p><a href="https://github.com/monero-project/kovri-site/blob/master/kovri.i2p/legal/copyright.md" target="_blank">Copyright</a>
+               <p><a href="https://github.com/monero-project/kovri-site/blob/master/kovri.i2p/legal/copyright.md" target="_blank" rel="noreferrer, noopener">Copyright</a>
                 &copy; 2017, The Kovri I2P Router Project </p>
          </div>
    </div>


### PR DESCRIPTION
Increases privacy by requiring supported browsers to *not* send a
referer header. Also prevents tabnabbing.