### PR TITLE
Point 'Style' submenu to correct markdown file

### DIFF
--- a/kovri.i2p/doc/style.html
+++ b/kovri.i2p/doc/style.html
@@ -4,4 +4,4 @@ title: titles.style
 permalink: /style
 ---
 
-{% tf quality.md %}
+{% tf style.md %}


### PR DESCRIPTION
Fixes https://github.com/monero-project/kovri-site/issues/34.