### PR TITLE
Updated Get Started page for new documentation structure

### DIFF
--- a/kovri.i2p/_i18n/da.yml
+++ b/kovri.i2p/_i18n/da.yml
@@ -46,8 +46,7 @@ home:
   blog: Blog
   
 get-started:
-  intro1: A quickstart guide for getting Kovri up and running. For further information on any topic, please see the
-  intro2: documentation.
+  intro1: A quickstart guide for getting Kovri up and running.
   support: 1. Contact & Support
   support_para1: First off, if you run into trouble on any of these steps, it's useful to know where you can find help. Please go to our
   support_para2: IRC channel for general Kovri inquiries and our

--- a/kovri.i2p/_i18n/de.yml
+++ b/kovri.i2p/_i18n/de.yml
@@ -46,8 +46,7 @@ home:
   blog: Blog
   
 get-started:
-  intro1: A quickstart guide for getting Kovri up and running. For further information on any topic, please see the
-  intro2: documentation.
+  intro1: A quickstart guide for getting Kovri up and running.
   support: 1. Contact & Support
   support_para1: First off, if you run into trouble on any of these steps, it's useful to know where you can find help. Please go to our
   support_para2: IRC channel for general Kovri inquiries and our

--- a/kovri.i2p/_i18n/en.yml
+++ b/kovri.i2p/_i18n/en.yml
@@ -45,8 +45,7 @@ home:
   blog: Blog
   
 get-started:
-  intro1: A quickstart guide for getting Kovri up and running. For further information on any topic, please see the
-  intro2: documentation.
+  intro1: A quickstart guide for getting Kovri up and running.
   support: 1. Contact & Support
   support_para1: First off, if you run into trouble on any of these steps, it's useful to know where you can find help. Please go to our
   support_para2: IRC channel for general Kovri inquiries and our

--- a/kovri.i2p/_i18n/es.yml
+++ b/kovri.i2p/_i18n/es.yml
@@ -46,8 +46,7 @@ home:
   blog: Blog
   
 get-started:
-  intro1: A quickstart guide for getting Kovri up and running. For further information on any topic, please see the
-  intro2: documentation.
+  intro1: A quickstart guide for getting Kovri up and running.
   support: 1. Contact & Support
   support_para1: First off, if you run into trouble on any of these steps, it's useful to know where you can find help. Please go to our
   support_para2: IRC channel for general Kovri inquiries and our

--- a/kovri.i2p/_i18n/fr.yml
+++ b/kovri.i2p/_i18n/fr.yml
@@ -46,8 +46,7 @@ home:
   blog: Blog
 
 get-started:
-  intro1: Voici un guide de démarrage rapide pour faire fonctionner Kovri. Pour plus d'informations sur tout sujet, consultez-la
-  intro2: documentation.
+  intro1: Voici un guide de démarrage rapide pour faire fonctionner Kovri.
   support: 1. Contact & Assistance
   support_para1: Avant tout, si vous rencontrez des problèmes avec l'une de ces étapes, il est utile de savoir où trouver de l'aide. Rendez-vous sur notre canal IRC
   support_para2: pour des questions d'ordre général sur Kovri et notre canal

--- a/kovri.i2p/_i18n/it.yml
+++ b/kovri.i2p/_i18n/it.yml
@@ -46,8 +46,7 @@ home:
   blog: Blog
   
 get-started:
-  intro1: A quickstart guide for getting Kovri up and running. For further information on any topic, please see the
-  intro2: documentation.
+  intro1: A quickstart guide for getting Kovri up and running.
   support: 1. Contact & Support
   support_para1: First off, if you run into trouble on any of these steps, it's useful to know where you can find help. Please go to our
   support_para2: IRC channel for general Kovri inquiries and our

--- a/kovri.i2p/_i18n/ru.yml
+++ b/kovri.i2p/_i18n/ru.yml
@@ -46,8 +46,7 @@ home:
   blog: Blog
   
 get-started:
-  intro1: A quickstart guide for getting Kovri up and running. For further information on any topic, please see the
-  intro2: documentation.
+  intro1: A quickstart guide for getting Kovri up and running.
   support: 1. Contact & Support
   support_para1: First off, if you run into trouble on any of these steps, it's useful to know where you can find help. Please go to our
   support_para2: IRC channel for general Kovri inquiries and our

--- a/kovri.i2p/get-started.html
+++ b/kovri.i2p/get-started.html
@@ -5,7 +5,7 @@ permalink: get-started
 ---
 
 <div class="text-center container description">
-    <p>{% t get-started.intro1 %} <a href="docs.html">{% t get-started.intro2 %}</a></p>
+    <p>{% t get-started.intro1 %}</p>
 </div>
 <div class="using">
     <section class="container">
@@ -36,7 +36,7 @@ permalink: get-started
                         </div>
                     </div>
                     <div class="row start-xs">
-                        <p><a href="https://github.com/monero-project/kovri#nightly-releases-bleeding-edge">{% t get-started.download_para1 %}</a> {% t get-started.download_para2 %} <a href="docs.html">{% t get-started.download_para3 %} </a> {% t get-started.download_para4 %}</p>
+                        <p><a href="https://github.com/monero-project/kovri#nightly-releases-bleeding-edge">{% t get-started.download_para1 %}</a> {% t get-started.download_para2 %} <a href="https://github.com/monero-project/kovri#building">{% t get-started.download_para3 %} </a> {% t get-started.download_para4 %}</p>
                     </div>
                 </div>
             </div>
@@ -48,7 +48,7 @@ permalink: get-started
                         </div>
                     </div>
                     <div class="row start-xs">
-                        <p>{% t get-started.firewall_para1 %} <a href="docs.html">{% t get-started.firewall_para2 %}</a> {% t get-started.firewall_para3 %}</p>
+                        <p>{% t get-started.firewall_para1 %} <a href="user-guide.html">{% t get-started.firewall_para2 %}</a> {% t get-started.firewall_para3 %}</p>
                     </div>
                 </div>
             </div>
@@ -90,7 +90,7 @@ permalink: get-started
                         </div>
                     </div>
                     <div class="row start-xs">
-                        <p>{% t get-started.tunnels_para1 %} <a href="docs.html">{% t get-started.tunnels_para2 %}</a> {% t get-started.tunnels_para3 %}</p>
+                        <p>{% t get-started.tunnels_para1 %} <a href="user-guide.html">{% t get-started.tunnels_para2 %}</a> {% t get-started.tunnels_para3 %}</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- Updated all links to direct to User Guide or Building section (Github) rather than docs.html
- Removed reference to docs.html in the intro section