### PR TITLE
Fixed link still pointing to docs.html in index.html

### DIFF
--- a/kovri.i2p/index.html
+++ b/kovri.i2p/index.html
@@ -51,7 +51,7 @@ permalink: index
                     </div>
                     <div class="row center-xs">
                         <p><a href="https://github.com/monero-project/kovri#nightly-releases-bleeding-edge" class="btn-fixed">{% t home.binaries %}</a></p>
-                        <p><a href="docs.html" class="btn-fixed">{% t home.buildsource %}</a></p>
+                        <p><a href="https://github.com/monero-project/kovri#building" class="btn-fixed">{% t home.buildsource %}</a></p>
                     </div>
                </div>
             </div>


### PR DESCRIPTION
- Now redirects to building instructions in Github